### PR TITLE
Update EthereumPrivateKey.swift

### DIFF
--- a/source/Web3/Classes/Core/Transaction/EthereumPrivateKey.swift
+++ b/source/Web3/Classes/Core/Transaction/EthereumPrivateKey.swift
@@ -212,8 +212,9 @@ public final class EthereumPrivateKey {
 
     // MARK: - Convenient functions
 
-    public func sign(message: Bytes) throws -> (v: UInt, r: Bytes, s: Bytes) {
-        var hash = SHA3(variant: .keccak256).calculate(for: message)
+    public func sign(message: Bytes,needToHash: Bool = false) throws -> (v: UInt, r: Bytes, s: Bytes) {
+        var hash: Bytes = message
+        if needToHash { hash = SHA3(variant: .keccak256).calculate(for: message) }
         guard hash.count == 32 else {
             throw Error.internalError
         }


### PR DESCRIPTION
signMessage方法支持外部控制是否需要做一次SHA3算法签名（原来是默认都会做一次SHA3算法，但这样不能支持walletConnect中的eth_sign签名）